### PR TITLE
Solves the "Wrong binary data format" error if target table have different columns order #1

### DIFF
--- a/pg_util.h
+++ b/pg_util.h
@@ -42,7 +42,7 @@ void pg_begin(PGconn *conn);
 void pg_end(PGconn *conn);
 void pg_unprepare(PGconn *conn, char *stmt_name);
 void pg_exec(PGconn *conn, char *query);
-int pg_begin_copy(PGconn *conn, char *tablename);
+int pg_begin_copy(PGconn *conn, char *tablename, PGconn *src_conn);
 int pg_send_copy_data(PGconn *conn, ResultSet *rset);
 int pg_finish_copy(PGconn *conn);
 

--- a/sync.conf
+++ b/sync.conf
@@ -24,6 +24,6 @@ password =
 
 #this is a comment
 
-table1
-table2
-table3
+public.table1
+otherschema.table2
+otherschema.table3


### PR DESCRIPTION
solves the problem of the order of columns in the binary data at the time of making the copy, the disadvantage of DEALLOCATE is corrected by the extra point for the schemes and table.

CREATE TABLE public."user"
(
  id_user serial,
  cel text,
  name text,
  col1 integer,
  col2 text,
  col3 integer,
  col4 varchar(1),
  col5 date default now(),
  CONSTRAINT user_pk PRIMARY KEY (id_user)
)


CREATE TABLE public."user"
(
  id_user serial,
  cel text,
  col5 date default now(),
  name text,
  col3 integer,
  col1 integer,
  col4 varchar(1),
  col2 text,
  CONSTRAINT user_pk PRIMARY KEY (id_user)
)

first order

![image](https://user-images.githubusercontent.com/8085532/49565819-21eec080-f8ee-11e8-91a0-b76397bf0241.png)

execution

![image](https://user-images.githubusercontent.com/8085532/49565836-3af77180-f8ee-11e8-9d97-6b8ac5bc55c6.png)

correct insertion

![image](https://user-images.githubusercontent.com/8085532/49565874-5d898a80-f8ee-11e8-80ed-04b640e9999b.png)


